### PR TITLE
fix atc aircraft data

### DIFF
--- a/headwind-a330-900/SimObjects/Airplanes/Headwind_A330neo/aircraft.cfg
+++ b/headwind-a330-900/SimObjects/Airplanes/Headwind_A330neo/aircraft.cfg
@@ -1,21 +1,21 @@
 [VERSION]
-major  =1
-minor  =0
+major = 1
+minor = 0
 
 [GENERAL]
-atc_type  ="AIRBUS"
-atc_model  ="A330-900 NEO"
+atc_type = "TT:ATCCOM.ATC_NAME AIRBUS.0.text"
+atc_model = "TT:ATCCOM.AC_MODEL A330.0.text"
 Category = "airplane"
-performance  ="Maximum speed\nMach 0.86 (496 kn)\n\nRange\n7,200nmi (13,334 km)\n\nCeiling\n41,450 ft (12 634m)\n\nEngine\nRolls-Royce Trent 7000-72"
+performance= "Maximum speed\nMach 0.86 (496 kn)\n\nRange\n7,200nmi (13,334 km)\n\nCeiling\n41,450 ft (12 634m)\n\nEngine\nRolls-Royce Trent 7000-72"
 editable = 1
 wip_indicator = 2
-icao_type_designator =A339
-icao_manufacturer =AIRBUS
-icao_model =A339
-icao_engine_type =Jet
-icao_engine_count =2
-icao_WTC =H
-icao_generic =0
+icao_type_designator = "A339"
+icao_manufacturer = "AIRBUS"
+icao_model = "A-330-900"
+icao_engine_type = "Jet"
+icao_engine_count = 2
+icao_WTC = "H"
+icao_generic = 0
 
 [PILOT]
 pilot ="Pilot_Female_Uniform"


### PR DESCRIPTION
<!-- Original Pull Request Template made by the fantastic FlyByWire Team for the A32NX <3 -->
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

## Summary of Changes
The Data changed to fit the official icao values.

## Screenshots (if necessary)

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos).  -->

## Additional context

Data does't match with the atc database entries by Asobo which leads to some issues:

1. As the icao information don't match people flying on vatsim or other multiplayers without having the headwind 330 Neo installed won't have a matching replacement (e.g. the one provided by AIG).
2. As the atc entries don't match the Database the aircraft won't be called by the correct type - currently it won't have a type at all

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
Provided by [Delta ²k5]

## Testing instructions

<!-- DO NOT DELETE THIS -->
## How to download the PR for Testing

Every new commit to this PR will cause a new A330-900neo artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **HEADWIND-A339** download link at the bottom of the page