### PR TITLE
adjust values for managed speed mach, range, zfw and fuel

### DIFF
--- a/src-a339/html_ui/Pages/VCockpit/Instruments/Airliners/Headwind_A339/FMC/A32NX_FMCMainDisplay.js
+++ b/src-a339/html_ui/Pages/VCockpit/Instruments/Airliners/Headwind_A339/FMC/A32NX_FMCMainDisplay.js
@@ -347,7 +347,7 @@ class FMCMainDisplay extends BaseAirliners {
         this._routeAltFuelTime = 0;
         this._routeTripFuelWeight = 0;
         this._routeTripTime = 0;
-        this._defaultTaxiFuelWeight = 0.2;
+        this._defaultTaxiFuelWeight = 0.5;
         this._rteRsvPercentOOR = false;
         this._rteReservedWeightEntered = false;
         this._rteReservedPctEntered = false;
@@ -444,7 +444,7 @@ class FMCMainDisplay extends BaseAirliners {
         // this.managedSpeedClimbMachIsPilotEntered = false;
         this.managedSpeedCruise = 300;
         this.managedSpeedCruiseIsPilotEntered = false;
-        this.managedSpeedCruiseMach = .80;
+        this.managedSpeedCruiseMach = .82;
         // this.managedSpeedCruiseMachIsPilotEntered = false;
         this.managedSpeedDescend = 300;
         this.managedSpeedDescendIsPilotEntered = false;
@@ -462,7 +462,7 @@ class FMCMainDisplay extends BaseAirliners {
         this.altDestination = undefined;
         this.flightNumber = undefined;
         this.cruiseTemperature = undefined;
-        this.taxiFuelWeight = 0.2;
+        this.taxiFuelWeight = 0.5;
         this.blockFuel = undefined;
         this.zeroFuelWeight = undefined;
         this.zeroFuelWeightMassCenter = undefined;
@@ -1090,7 +1090,7 @@ class FMCMainDisplay extends BaseAirliners {
 
         SimVar.SetSimVarValue("K:VS_SLOT_INDEX_SET", "number", 1);
 
-        this.taxiFuelWeight = 0.2;
+        this.taxiFuelWeight = 0.5;
         CDUInitPage.updateTowIfNeeded(this);
     }
 
@@ -3816,7 +3816,7 @@ class FMCMainDisplay extends BaseAirliners {
     // only used by trySetMinDestFob
     //TODO: Can this be util?
     isMinDestFobInRange(fuel) {
-        return 0 <= fuel && fuel <= 80.0;
+        return 0 <= fuel && fuel <= 111.7;
     }
 
     //TODO: Can this be util?
@@ -3847,7 +3847,7 @@ class FMCMainDisplay extends BaseAirliners {
 
     //TODO: Can this be util?
     isZFWInRange(zfw) {
-        return 109.0 <= zfw && zfw <= 181.0;
+        return 132.5 <= zfw && zfw <= 177.0;
     }
 
     //TODO: Can this be util?
@@ -3857,7 +3857,7 @@ class FMCMainDisplay extends BaseAirliners {
 
     //TODO: Can this be util?
     isBlockFuelInRange(fuel) {
-        return 0 <= fuel && fuel <= 80;
+        return 0 <= fuel && fuel <= 111.7;
     }
 
     /**


### PR DESCRIPTION
<!-- Original Pull Request Template made by the fantastic FlyByWire Team for the A32NX <3 -->
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #6 

## Summary of Changes
Changes default taxi fuel weight, zfw range, block fuel range in fmc.

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos).  -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for Testing

Every new commit to this PR will cause a new A330-900neo artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **HEADWIND-A339** download link at the bottom of the page